### PR TITLE
Use `moment().subtract(number, period)` syntax to eliminate deprecation warning

### DIFF
--- a/readable-range.js
+++ b/readable-range.js
@@ -49,7 +49,7 @@
             dDiff--;
         }
         if (dDiff < 0) {
-            var daysInLastFullMonth = moment(m2.year() + '-' + (m2.month() + 1), "YYYY-MM").subtract('months', 1).daysInMonth();
+            var daysInLastFullMonth = moment(m2.year() + '-' + (m2.month() + 1), "YYYY-MM").subtract(1, 'M').daysInMonth();
             if (daysInLastFullMonth < m1.date()) { // 31/01 -> 2/03
                 dDiff = daysInLastFullMonth + dDiff + (m1.date() - daysInLastFullMonth);
             } else {


### PR DESCRIPTION
Currently, using the `preciseDiff` method with the latest version of Moment (2.10.2) produces this deprecation warning in the console:

```
Deprecation warning: moment().subtract(period, number) is deprecated. Please use moment().subtract(number, period).
```

This pull request switches to the `moment().subtract(number, period)` syntax, which eliminates the warning.