### PR TITLE
Fix Webpack's misused require function error

### DIFF
--- a/moment-precise-range.js
+++ b/moment-precise-range.js
@@ -1,4 +1,4 @@
-if (typeof moment === "undefined" && require) {
+if (typeof moment === "undefined" && typeof require === 'function') {
     moment = require('moment');
 }
 


### PR DESCRIPTION
A Webpack error is produced when attempting to build any project that requires or imports the moment-precise-range plugin:

    WARNING in ./~/moment-precise-range-plugin/moment-precise-range.js
    Critical dependencies:
    1:37-44 require function is used in a way in which dependencies cannot be statically extracted
    @ ./~/moment-precise-range-plugin/moment-precise-range.js 1:37-44

The issue goes away if you make this change; while still retaining the original purpose of checking for require (i.e. to ensure require can be called).