### PR TITLE
Change moment dependency to a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "moment-precise-range-plugin",
   "version": "1.2.3",
-  "dependencies": {
+  "peerDependencies": {
     "moment": ">=2.9.0"
   },
   "description": "This is a plugin for the moment.js JavaScript library, to display date/time ranges precisely, in a human-readable format.",


### PR DESCRIPTION
I believe this was causing trouble here: https://github.com/decaffeinate/bulk-decaffeinate/issues/140

The normal (non-peer) dependency on moment means that package managers have the
option to either share the dependency with another package or to install a
separate copy of moment just for this package. But if moment-precise-range gets
its own copy of moment, then it'll be modifying that copy and not the one I want
modified. peerDependencies means "never install a separate copy of moment, and
instead make sure that `require('moment')` resolves to some moment installation
from some other package", which is what we want here.

Another approach that would be even more robust is to expose a function that
takes the moment package as an argument and modifies it. That way I can be sure
that the package being modified is the one I'm using. But I think that would be
a breaking change.